### PR TITLE
Post Install Tasks for Contiv

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 ## standalone kubeadm deployment
 ### Orignal code credit goes to https://github.com/ben-st/ansible-kubeadm. I used it as a base and changed the CNI to Contiv (by Cisco).
 
-- Requires Ansible 1.2 or newer
+- Requires Ansible 2.4 or newer
+- Python netaddr 'pip install netaddr'
 - Expects 3 ubuntu nodes (at least 16.04)
 - Expects passwordless sudo
 

--- a/contiv_network_configuration.yml
+++ b/contiv_network_configuration.yml
@@ -1,0 +1,36 @@
+---
+# This playbook is used to configure basic networking options in contiv.
+# The expectation is it will run on the master host using netctl installed previously.
+# The k8 cluster should be setup and in a running state.
+# BGP Configuration is optional. Comment out BGP roles as necessary. 
+
+
+- name: Gather facts on all hosts
+  hosts: 
+    - master
+    - worker
+  remote_user: "{{ ansible_remote_user }}"
+  gather_facts: True
+  become: yes
+  become_method: sudo
+
+- name: Configure networks and BGP
+  hosts: master
+  remote_user: "{{ ansible_remote_user }}"
+  become: yes
+  become_method: sudo
+  roles:
+    - contiv_network_cfg
+    - contiv_bgp_peers
+    
+- name: Configure BGP on router
+  hosts: bgprouter
+  gather_facts: True
+  connection: local
+  vars:
+    rtr_auth:
+      username: cisco
+      host: '{{ ansible_host }}'
+  roles:
+    - bgp_iosxr
+  

--- a/group_vars/all
+++ b/group_vars/all
@@ -4,3 +4,29 @@ kubeadm_token: db85f7.cff657b31b20eed5
 master_ip: "{{ hostvars['master1']['ansible_eth0']['ipv4']['address'] }}"
 
 ansible_remote_user: ubuntu
+
+
+contiv_nets:
+  # This network name is required for host to access pods.
+  contivh1:
+    net_type: -n infra
+    net_sub:  -s 192.0.2.0/24
+    net_gw:   -g 192.0.2.1
+  # This is used for pods that do not have a io.contiv.network label  
+  default-net:
+    net_type: -n data
+    net_sub:  -s 172.16.10.10-172.16.10.250/24
+    net_gw:   -g 172.16.10.1
+  blue:
+    net_type: -n data
+    net_sub:  -s 172.17.0.5-172.17.15.250/20
+    net_gw:
+  green:
+    net_type: -n data
+    net_sub:  -s 172.18.0.5-172.18.15.250/20
+    net_gw:
+
+
+bgp_router_ip: 172.16.1.1
+bgp_router_as: 65000
+bgp_myas: 65001

--- a/inventory
+++ b/inventory
@@ -6,6 +6,8 @@ master1 ansible_ssh_host=192.168.1.10
 192.168.1.11
 192.168.1.12
 
+[bgprouter]
+rtr1 ansible_host=172.16.1.1
 
 [master:vars]
 ansible_ssh_common_args='-o StrictHostKeyChecking=no'

--- a/roles/bgp_iosxr/tasks/main.yml
+++ b/roles/bgp_iosxr/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Configure BGP router with neighbors
+  ios_config:
+    provider: '{{ rtr_auth }}'
+    lines: 
+      - neighbor {{ hostvars[item]['ansible_eth0']['ipv4']['address'] }} remote-as {{ bgp_myas }}
+    parents: router bgp {{ bgp_router_as }}
+  with_items:
+    - "{{ groups['master'] }}"
+    - "{{ groups['worker'] }}"

--- a/roles/contiv/templates/contiv12.yaml.j2
+++ b/roles/contiv/templates/contiv12.yaml.j2
@@ -1,9 +1,9 @@
----
 # Downloaded from https://raw.githubusercontent.com/contiv/netplugin/release-1.2/install/k8s/contiv/contiv.yaml
-# Modified with: sed -i -e 's/__NETMASTER_IP__/{{ master_ip }}/g' -e 's/__VLAN_IF__//g' contiv.yaml
+# Modified with: sed -e 's/__NETMASTER_IP__/{{ master_ip }}/g' -e 's/__VLAN_IF__//g' contiv.yaml
 # This ConfigMap is used to configure a self-hosted Contiv installation.
 # It can be used with an external cluster store(etcd or consul) or used
 # with the etcd instance being installed as contiv-etcd
+---
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -13,6 +13,7 @@ data:
   contiv_mode: kubernetes
   contiv_fwdmode: routing
   contiv_netmode: vxlan
+  contiv_vlan_if: 'eth1'
   # The location of your cluster store. This is set to the
   # avdertise-client value below from the contiv-etcd service.
   # Change it to an external etcd/consul instance if required.
@@ -30,7 +31,8 @@ data:
        "K8S_CA": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
        "K8S_KEY": "",
        "K8S_CERT": "",
-       "K8S_TOKEN": ""
+       "K8S_TOKEN": "",
+       "SVC_SUBNET": "10.96.0.0/12"
     }
 ---
 
@@ -105,7 +107,10 @@ spec:
             - name: CONTIV_ROLE
               value: netplugin
             - name: CONTIV_NETPLUGIN_VLAN_UPLINKS
-              value: 
+              valueFrom:
+                configMapKeyRef:
+                  name: contiv-config
+                  key: contiv_vlan_if
             - name: CONTIV_NETPLUGIN_MODE
               valueFrom:
                 configMapKeyRef:

--- a/roles/contiv_bgp_peers/tasks/main.yml
+++ b/roles/contiv_bgp_peers/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Add BGP Peers for Workers
+  command: > 
+    netctl bgp create 
+    --router-ip {{ hostvars[item]['ansible_eth0']['ipv4']['address'] }}/{{ (hostvars[item]['ansible_eth0']['ipv4']['address'] + '/' + hostvars[item]['ansible_eth0']['ipv4']['netmask']) | ipaddr('prefix') }} 
+    --as {{ bgp_myas }} 
+    --neighbor {{ bgp_router_ip }} 
+    --neighbor-as {{ bgp_router_as }} 
+    {{ hostvars[item]['ansible_hostname'] }}
+  with_items: 
+    - "{{ groups['master'] }}"
+    - "{{ groups['worker'] }}"
+

--- a/roles/contiv_network_cfg/tasks/main.yml
+++ b/roles/contiv_network_cfg/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Configure Networks
+  command: netctl net create -t default {{ item.value.net_type }} {{ item.value.net_sub }} {{ item.value.net_gw }} {{ item.key }} 
+  with_dict: "{{ contiv_nets }}"
+  

--- a/site.yml
+++ b/site.yml
@@ -1,15 +1,17 @@
 ---
 # This playbook deploys a simple kubeadm install.
 - name: Bootstrap Tasks
-  hosts: all
-  remote_user: ubuntu
+  hosts: 
+    - master
+    - worker
+  remote_user: "{{ ansible_remote_user }}"
   gather_facts: False
   roles:
     - common
 
 - name: Install Kubernetes master
   hosts: master
-  remote_user: ubuntu
+  remote_user: "{{ ansible_remote_user }}"
   become: yes
   become_method: sudo
   roles:
@@ -19,7 +21,7 @@
     - contiv
 
 - name: Install nodes
-  remote_user: ubuntu
+  remote_user: "{{ ansible_remote_user }}"
   hosts: worker
   become: yes
   become_method: sudo
@@ -27,3 +29,5 @@
     - docker
     - kubeadm
     - worker
+
+- import_playbook: contiv_network_configuration.yml


### PR DESCRIPTION
Adding additional configurations to support post-install configurations of networks and BGP peers. Check contiv.io for configuration best practics.
FYI - BGP is not used in vxlan routing mode. Tasks should be commented out if not needed.