### PR TITLE
Added a reset before kubeadm init

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -5,6 +5,7 @@ master_ip: "{{ hostvars['master1']['ansible_eth0']['ipv4']['address'] }}"
 
 ansible_remote_user: ubuntu
 
+kubeadm_reset_before_init: true
 
 contiv_nets:
   # This network name is required for host to access pods.

--- a/roles/master/tasks/main.yml
+++ b/roles/master/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
-
+- name: Reset kubeadm before init in case this is not the first run
+  command: kubeadm reset
+  when: kubeadm_reset_before_init
+  
 - name: kubeadm init with pre generated token
   command: kubeadm init --token {{ kubeadm_token }} --service-cidr 10.96.0.0/12
   
@@ -33,6 +36,7 @@
     remote_src: yes
     owner: "{{ ansible_remote_user }}"
     group: "{{ ansible_remote_user }}"
+    force: yes
     mode: 0400
 
 - pause:

--- a/roles/worker/tasks/main.yml
+++ b/roles/worker/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Reset kubeadm before init in case this is not the first run
+  command: kubeadm reset
+  when: kubeadm_reset_before_init
 
 - name: kubeadm join with pre generated token
   command: kubeadm join --token {{ kubeadm_token }} {{ master_ip }}:6443 --discovery-token-unsafe-skip-ca-verification


### PR DESCRIPTION
Added a reset before kubeadm init to flush everything incase the init… has already been run.

This allows the playbook to be run multiple times on the same host without error out on kubeadm init.